### PR TITLE
Fix ctrl+k not working & being captured by browser

### DIFF
--- a/palette/static/admin/palette.js
+++ b/palette/static/admin/palette.js
@@ -174,7 +174,7 @@ document.addEventListener("DOMContentLoaded", executePalette, false);
 document.addEventListener("keydown", (event) => {
   const paletteIsVisible = window.paletteComponent.style.display === "flex"
 
-  if (event.ctrlKey && event.key === "k") {
+  if ((event.ctrlKey || event.metaKey) && event.key === "k") {
     window.paletteComponent.style.display = paletteIsVisible ? "none" : "flex";
     document.getElementById("paletteInput").focus();
     event.preventDefault();

--- a/palette/static/admin/palette.js
+++ b/palette/static/admin/palette.js
@@ -174,9 +174,10 @@ document.addEventListener("DOMContentLoaded", executePalette, false);
 document.addEventListener("keydown", (event) => {
   const paletteIsVisible = window.paletteComponent.style.display === "flex"
 
-  if (event.metaKey && event.key === "k") {
+  if (event.ctrlKey && event.key === "k") {
     window.paletteComponent.style.display = paletteIsVisible ? "none" : "flex";
     document.getElementById("paletteInput").focus();
+    event.preventDefault();
   }
 
   if (!paletteIsVisible) {


### PR DESCRIPTION
With this changes it works for me both on Firefox and Chrome (on Ubuntu 20.04). Fixes #8 