### PR TITLE
Disable input autocomplete/spellcheck/autocaptialize

### DIFF
--- a/palette/static/admin/palette.js
+++ b/palette/static/admin/palette.js
@@ -147,6 +147,10 @@ function executePalette() {
   const inputElement = document.createElement("input");
   inputElement.id = "paletteInput";
   inputElement.classList.add("palette-input");
+  inputElement.setAttribute("type", "text");
+  inputElement.setAttribute("spellcheck", "false");
+  inputElement.setAttribute("autocomplete", "off");
+  inputElement.setAttribute("autocapitalize", "off");
   inputElement.placeholder = "Type a command or search...";
   inputElement.onkeyup = function (event) {
     if (event.key === "Enter") {


### PR DESCRIPTION
You may or not may not be interested in this update, but it fixes a pain point for me :)

This UI was getting in the way of using the arrow keys to navigate up and down the list. I've tested the fix on Chrome + Safari + Firefox on MacOS.

I only noticed after opening this MR that it was already mentioned here #13.

Before:

<img width="429" height="237" alt="Screenshot 2025-09-24 at 10 04 46" src="https://github.com/user-attachments/assets/8b91b001-7005-4edf-8f98-5d3cd372ad88" />

After:

<img width="281" height="244" alt="Screenshot 2025-09-24 at 10 13 25" src="https://github.com/user-attachments/assets/812dc687-db0b-4070-beb4-80f7e5f3b9a9" />